### PR TITLE
Performance improvements + dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,18 +4,18 @@
 
     <groupId>org.nasabot</groupId>
     <artifactId>nasabot</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
         <java.version>11</java.version>
-        <maven.version>3.2.1</maven.version>
     </properties>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -23,6 +23,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
@@ -42,27 +43,26 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.6</version>
+            <version>5.0.0-beta.19</version>
         </dependency>
 
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20200518</version>
+            <version>20231013</version>
         </dependency>
 
         <dependency>
             <groupId>pw.chew</groupId>
             <artifactId>jda-chewtils</artifactId>
             <version>2.0-SNAPSHOT</version>
-            <scope>compile</scope>
             <type>pom</type>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.9.3</version>
+            <version>4.12.0</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/nasabot/nasabot/NASABot.java
+++ b/src/main/java/org/nasabot/nasabot/NASABot.java
@@ -7,6 +7,8 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.entities.Activity;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+
 import org.nasabot.nasabot.commands.APODSlashCommand;
 import org.nasabot.nasabot.commands.GetPostChannelSlashCommand;
 import org.nasabot.nasabot.commands.GetPostTimeSlashCommand;
@@ -64,7 +66,7 @@ public class NASABot {
         } catch (Exception e) {
             e.printStackTrace();
             System.out.println("Cannot get Discord token.");
-            System.exit(0);
+            System.exit(1);
         }
 
         CommandClientBuilder builder = new CommandClientBuilder();
@@ -87,7 +89,7 @@ public class NASABot {
         CommandClient commandClient = builder.build();
         slashCommands = commandClient.getSlashCommands();
 
-        jda = JDABuilder.createDefault(token).addEventListeners(commandClient).build().awaitReady();
+        jda = JDABuilder.createLight(token, GatewayIntent.GUILD_MESSAGES) .addEventListeners(commandClient).build().awaitReady();
         jda.getPresence().setPresence(OnlineStatus.ONLINE, Activity.of(Activity.ActivityType.LISTENING, "commands..."));
         dbClient = new DBClient();
         healthCheckClient = new HealthCheckClient();

--- a/src/main/java/org/nasabot/nasabot/commands/InfoSlashCommand.java
+++ b/src/main/java/org/nasabot/nasabot/commands/InfoSlashCommand.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.Guild;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 public class InfoSlashCommand extends NASASlashCommand {
 
@@ -20,13 +21,10 @@ public class InfoSlashCommand extends NASASlashCommand {
     protected void execute(SlashCommandEvent slashCommandEvent) {
         this.insertCommand(slashCommandEvent);
 
-        List<Guild> guildList = NASABot.jda.getGuilds();
-        int numServers = guildList.size();
-        int numPlayers  = 0;
-        for (Guild guild : guildList) {
-            numPlayers += guild.getMemberCount();
-        }
-
+        final List<Guild> guilds = NASABot.jda.getGuilds();
+        final int numServers = guilds.size();
+        final int numPlayers = guilds.stream().collect(Collectors.summingInt(Guild::getMemberCount));
+        
         EmbedBuilder embedBuilder = new EmbedBuilder();
         embedBuilder.setTitle("NASABot");
         embedBuilder.setDescription("Information about the bot.");

--- a/src/main/java/org/nasabot/nasabot/utils/APODSchedulePostTask.java
+++ b/src/main/java/org/nasabot/nasabot/utils/APODSchedulePostTask.java
@@ -6,6 +6,7 @@ import org.nasabot.nasabot.NASABot;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.text.SimpleDateFormat;
 import java.util.Objects;
@@ -26,7 +27,8 @@ public class APODSchedulePostTask extends TimerTask {
         JSONArray postChannels = NASABot.dbClient.getPostChannelsForPostTimeOption(timeOption);
 
         for (int i = 0; i < postChannels.length(); i++) {
-            sendAPODToChannel(postChannels.getJSONObject(i).getString("server_id"), postChannels.getJSONObject(i).getString("channel_id"), embed);
+            JSONObject channelObject = postChannels.getJSONObject(i);
+            sendAPODToChannel(channelObject.getString("server_id"), channelObject.getString("channel_id"), embed);
         }
 
         if (NASABot.isLoggingEnabled()) {

--- a/src/main/java/org/nasabot/nasabot/utils/AstronomyCalc.java
+++ b/src/main/java/org/nasabot/nasabot/utils/AstronomyCalc.java
@@ -10,19 +10,19 @@ import java.time.LocalDate;
  */
 public final class AstronomyCalc {
 
-    /** There was a new moon on January 10th, 2020. Use this as a reference. */
+    /** There was a new moon on April 30th, 2022. Use this as a reference. */
     public static final long MOON_REF = LocalDate.of(2022, 4, 30).toEpochDay();
 
     /** Moon cycles every 29.53 days */
     public static final double MOON_PHASE_LENGTH = 29.53059;
 
     /**
-     * Gets the moon phase for the given date. This date must be after 4/30/2022. Note that
-     * this calculation is not 100% accurate and may be off by a few days.
+     * Gets the moon phase for the given date. This date must be after 4/30/2022.
+     * Note that this calculation is not 100% accurate and may be off by a few days.
      * 
-     * @param year The year
+     * @param year  The year
      * @param month The month
-     * @param day The day
+     * @param day   The day
      * @return Moon phase
      */
     public static MoonType getMoonphase(int year, int month, int day) {
@@ -58,27 +58,21 @@ public final class AstronomyCalc {
      * Gets the number of days since the last new moon. This can be used to figure
      * out what the current phase is (new moon occurs every 29.53 days)
      * 
-     * @param year Current year
+     * @param year  Current year
      * @param month Current month (1-12)
-     * @param day Current day (1-28/29/30/31)
+     * @param day   Current day (1-28/29/30/31)
      * @return The number of days since the last new moon
      */
     public static double getDaysSinceNewMoon(int year, int month, int day) {
         double refDiff = LocalDate.of(year, month, day).toEpochDay() - MOON_REF;
-        assert refDiff > 0: "Must use a day after 4/30/2022";
+        assert refDiff > 0 : "Must use a day after 4/30/2022";
         double cycleCount = refDiff / MOON_PHASE_LENGTH;
         return (cycleCount % 1) * MOON_PHASE_LENGTH;
     }
 
     public static enum MoonType {
-        NEW("New"),
-        WANING_CRES("Waning Crescent"),
-        THIRD_QUART("Third Quarter"),
-        WANING_GIBB("Waning Gibbous"),
-        FULL("Full"),
-        WAXING_GIBB("Waxing Gibbous"),
-        FIRST_QUART("First Quarter"),
-        WAXING_CRES("Waxing Crescent");
+        NEW("New"), WANING_CRES("Waning Crescent"), THIRD_QUART("Third Quarter"), WANING_GIBB("Waning Gibbous"),
+        FULL("Full"), WAXING_GIBB("Waxing Gibbous"), FIRST_QUART("First Quarter"), WAXING_CRES("Waxing Crescent");
 
         private String phaseString;
 

--- a/src/main/java/org/nasabot/nasabot/utils/GeoNamesClient.java
+++ b/src/main/java/org/nasabot/nasabot/utils/GeoNamesClient.java
@@ -22,7 +22,7 @@ public class GeoNamesClient {
             username = resourceBundle.getString("geoNamesUsername");
         } catch (Exception e) {
             ErrorLogging.handleError("GeoNamesClient", "GeoNamesClient", "Cannot create GeoNamesClient.", e);
-            System.exit(0);
+            System.exit(1);
         }
     }
 
@@ -34,12 +34,12 @@ public class GeoNamesClient {
                     .addQueryParameter("lng", longitude)
                     .addQueryParameter("username", username);
             Request request = new Request.Builder().url(builder.build().toString()).build();
-            Response response = httpClient.newCall(request).execute();
-            JSONObject jsonObject = new JSONObject(Objects.requireNonNull(response.body()).string());
-            String country = jsonObject.optString("countryName", "Not currently over a country. " +
-                    "Generally this means the ISS is currently in international territory or over an ocean.");
-            response.close();
-            return country;
+            try (Response response = httpClient.newCall(request).execute()) {
+                JSONObject jsonObject = new JSONObject(Objects.requireNonNull(response.body()).string());
+                String country = jsonObject.optString("countryName", "Not currently over a country. " +
+                        "Generally this means the ISS is currently in international territory or over an ocean.");
+                return country;
+            }
         } catch (Exception e) {
             ErrorLogging.handleError("GeoNamesClient", "getCountryFromLatitudeLongitude", "Unable to get ISS location.", e);
         }

--- a/src/main/java/org/nasabot/nasabot/utils/NASAClient.java
+++ b/src/main/java/org/nasabot/nasabot/utils/NASAClient.java
@@ -1,19 +1,20 @@
 package org.nasabot.nasabot.utils;
 
+import java.awt.Color;
+import java.text.SimpleDateFormat;
+import java.util.Objects;
+import java.util.Random;
+import java.util.ResourceBundle;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.json.JSONArray;
-import org.json.JSONObject;
-
-import java.awt.Color;
-import java.text.SimpleDateFormat;
-import java.util.Objects;
-import java.util.Random;
-import java.util.ResourceBundle;
 
 public class NASAClient {
 
@@ -30,7 +31,7 @@ public class NASAClient {
             apiKey = resourceBundle.getString("NASAKey");
         } catch (Exception e) {
             ErrorLogging.handleError("NASAClient", "NASAClient", "Cannot contact NASA API.", e);
-            System.exit(0);
+            System.exit(1);
         }
     }
 
@@ -39,10 +40,9 @@ public class NASAClient {
             HttpUrl.Builder builder = Objects.requireNonNull(HttpUrl.parse(baseUrl + "/planetary/apod")).newBuilder();
             builder.addQueryParameter("api_key", apiKey).addQueryParameter("date", date);
             Request request = new Request.Builder().url(builder.build().toString()).build();
-            Response response = httpClient.newCall(request).execute();
-            MessageEmbed embed = formatPictureOfTheDay(Objects.requireNonNull(response.body()).string());
-            response.close();
-            return embed;
+            try (Response response = httpClient.newCall(request).execute()) {
+                return formatPictureOfTheDay(Objects.requireNonNull(response.body()).string());
+            }
         } catch (Exception e) {
             ErrorLogging.handleError("NASAClient", "getPictureOfTheDay", "Cannot get picture of the day.", e);
         }
@@ -57,12 +57,17 @@ public class NASAClient {
             JSONObject jsonObject = new JSONObject(POTDResponse);
             EmbedBuilder embedBuilder = new EmbedBuilder();
             embedBuilder
-                    .setTitle(jsonObject.getString("title"), String.format("https://apod.nasa.gov/apod/ap%s.html", jsonObject.getString("date").replaceAll("-", "").substring(2)))
-                    .setDescription(String.format("%s", outputDateFormat.format(inputDateFormat.parse(jsonObject.getString("date")))))
+                    .setTitle(jsonObject.getString("title"),
+                            String.format("https://apod.nasa.gov/apod/ap%s.html",
+                                    jsonObject.getString("date").replaceAll("-", "").substring(2)))
+                    .setDescription(String.format("%s",
+                            outputDateFormat.format(inputDateFormat.parse(jsonObject.getString("date")))))
                     .setColor(new Color(192, 32, 232))
-                    .addField("Description", jsonObject.getString("explanation").length() > 1024 ? String.format("%s", jsonObject.getString("explanation")).substring(0, 1020) + "..." : String.format("%s", jsonObject.getString("explanation")), false);
+                    .addField("Description", jsonObject.getString("explanation").length() > 1024
+                            ? String.format("%s", jsonObject.getString("explanation")).substring(0, 1020) + "..."
+                            : String.format("%s", jsonObject.getString("explanation")), false);
             if (jsonObject.has("hdurl")) {
-            	embedBuilder.addField("HD Image Link", jsonObject.getString("hdurl"), false);
+                embedBuilder.addField("HD Image Link", jsonObject.getString("hdurl"), false);
             }
             if (jsonObject.getString("url").contains("youtube.com") || jsonObject.getString("url").contains("video")) {
                 embedBuilder.addField("Video Link", jsonObject.getString("url"), false);
@@ -72,7 +77,8 @@ public class NASAClient {
             return embedBuilder.build();
         } catch (Exception e) {
             ErrorLogging.handleError("NASAClient", "formatPictureOfTheDay", "Cannot format picture of the day.", e);
-            return new EmbedBuilder().setTitle("Picture of the Day").addField("ERROR", "Unable to obtain Picture of the Day.", false).setColor(Color.RED).build();
+            return new EmbedBuilder().setTitle("Picture of the Day")
+                    .addField("ERROR", "Unable to obtain Picture of the Day.", false).setColor(Color.RED).build();
         }
     }
 
@@ -81,10 +87,9 @@ public class NASAClient {
             HttpUrl.Builder builder = Objects.requireNonNull(HttpUrl.parse(imageUrl + "/search")).newBuilder();
             builder.addQueryParameter("media_type", "image").addQueryParameter("q", searchTerm);
             Request request = new Request.Builder().url(builder.build().toString()).build();
-            Response response = httpClient.newCall(request).execute();
-            MessageEmbed embed = formatNASAImage(Objects.requireNonNull(response.body()).string());
-            response.close();
-            return embed;
+            try (Response response = httpClient.newCall(request).execute()) {
+                return formatNASAImage(Objects.requireNonNull(response.body()).string());
+            }
         } catch (Exception e) {
             ErrorLogging.handleError("NASAClient", "getNASAImage", "Cannot get NASA image.", e);
         }
@@ -98,23 +103,29 @@ public class NASAClient {
         try {
             JSONArray responseArray = new JSONObject(imageResponse).getJSONObject("collection").getJSONArray("items");
             if (responseArray.length() == 0) {
-                return new EmbedBuilder().setTitle("NASA Image").addField("ERROR", "No images found with that search term.", false).setColor(Color.RED).build();
+                return new EmbedBuilder().setTitle("NASA Image")
+                        .addField("ERROR", "No images found with that search term.", false).setColor(Color.RED).build();
             } else {
                 JSONObject selection = responseArray.getJSONObject(findSuitableImageSelection(responseArray));
                 EmbedBuilder embedBuilder = new EmbedBuilder();
                 embedBuilder.setTitle(selection.getJSONArray("data").getJSONObject(0).getString("nasa_id"));
                 embedBuilder.setDescription(
-                        selection.getJSONArray("data").getJSONObject(0).getString("description").length() > 1850 ?
-                                selection.getJSONArray("data").getJSONObject(0).getString("description").substring(0, 1500) + "..." :
-                                selection.getJSONArray("data").getJSONObject(0).getString("description"));
-                embedBuilder.addField("Date", outputDateFormat.format(inputDateFormat.parse(selection.getJSONArray("data").getJSONObject(0).getString("date_created"))), false);
+                        selection.getJSONArray("data").getJSONObject(0).getString("description").length() > 1850
+                                ? selection.getJSONArray("data").getJSONObject(0).getString("description").substring(0,
+                                        1500) + "..."
+                                : selection.getJSONArray("data").getJSONObject(0).getString("description"));
+                embedBuilder.addField("Date",
+                        outputDateFormat.format(inputDateFormat
+                                .parse(selection.getJSONArray("data").getJSONObject(0).getString("date_created"))),
+                        false);
                 embedBuilder.setColor(new Color(192, 32, 232));
                 embedBuilder.setImage(selection.getJSONArray("links").getJSONObject(0).getString("href"));
                 return embedBuilder.build();
             }
         } catch (Exception e) {
             ErrorLogging.handleError("NASAClient", "formatNASAImage", "Cannot format NASA image.", e);
-            return new EmbedBuilder().setTitle("NASA Image").addField("ERROR", "Unable to obtain an image.", false).setColor(Color.RED).build();
+            return new EmbedBuilder().setTitle("NASA Image").addField("ERROR", "Unable to obtain an image.", false)
+                    .setColor(Color.RED).build();
         }
     }
 
@@ -123,13 +134,15 @@ public class NASAClient {
             int index = new Random().nextInt(imageArray.length());
             JSONObject selection = imageArray.getJSONObject(index);
             try {
-                if (!selection.getJSONArray("data").getJSONObject(0).has("nasa_id")) {
+                JSONObject data = selection.getJSONArray("data").getJSONObject(0);
+                if (!data.has("nasa_id")) {
                     continue;
                 }
-                if (!selection.getJSONArray("data").getJSONObject(0).has("date_created")) {
+                if (!data.has("date_created")) {
                     continue;
                 }
-                if (!selection.getJSONArray("links").getJSONObject(0).has("href") || !selection.getJSONArray("links").getJSONObject(0).getString("render").equals("image")) {
+                JSONObject links = selection.getJSONArray("links").getJSONObject(0);
+                if (!links.has("href") || !links.getString("render").equals("image")) {
                     continue;
                 }
 

--- a/src/main/java/org/nasabot/nasabot/utils/TopGGClient.java
+++ b/src/main/java/org/nasabot/nasabot/utils/TopGGClient.java
@@ -1,16 +1,17 @@
 package org.nasabot.nasabot.utils;
 
+import java.util.ResourceBundle;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.json.JSONObject;
 import org.nasabot.nasabot.NASABot;
+
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.json.JSONObject;
-
-import java.util.ResourceBundle;
-import java.util.Timer;
-import java.util.TimerTask;
 
 public class TopGGClient {
 
@@ -25,7 +26,7 @@ public class TopGGClient {
             token = resourceBundle.getString("TopGGKey");
         } catch (Exception e) {
             ErrorLogging.handleError("TopGGClient", "TopGGClient", "Cannot contact TopGG API.", e);
-            System.exit(0);
+            System.exit(1);
         }
 
         TimerTask timerTask = new TopGGTimerTask();
@@ -35,10 +36,12 @@ public class TopGGClient {
 
     private static void setStats(OkHttpClient httpClient, int serverCount) {
         try {
-            RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"), new JSONObject().put("server_count", serverCount).toString());
-            Request request = new Request.Builder().url(url + "/stats").method("POST", requestBody).addHeader("Authorization", "Bearer " + token).build();
-            Response response = httpClient.newCall(request).execute();
-            response.close();
+            RequestBody requestBody = RequestBody.create(MediaType.parse("application/json"),
+                    new JSONObject().put("server_count", serverCount).toString());
+            Request request = new Request.Builder().url(url + "/stats").method("POST", requestBody)
+                    .addHeader("Authorization", "Bearer " + token).build();
+            try (Response response = httpClient.newCall(request).execute()) {
+            }
         } catch (Exception e) {
             ErrorLogging.handleError("TopGGClient", "setStats", "Cannot set stats.", e);
         }


### PR DESCRIPTION
This commit attempts to improve runtime performance and memory usage of NASABot. The main change is to configure JDABuilder to `createLight` instead of `createDefault`, and only enable the intents that the bot needs (AFAIK we only need `GUILD_MESSAGES`).

A heap dump indicates a retained memory size of ~70MB, mostly from caching. By disabling some caches (like voice channels which we don't care about) hopefully the memory usage improves.

Current usage:
![image](https://github.com/SniperNoob95/NASABot/assets/9405706/83868ac6-a19e-4a2b-a9a1-ed43a68af68f)

Also did some miscellaneous code cleanup and improvements in that regard, such as try-with-resources to ensure all resources are properly closed.
